### PR TITLE
Exclude Claude Code files from root deploy

### DIFF
--- a/.github/workflows/wpengine-deploy-root.yml
+++ b/.github/workflows/wpengine-deploy-root.yml
@@ -65,4 +65,6 @@ jobs:
           --exclude /package-lock.json \
           --exclude /patches.lock.json \
           --exclude /patches/ \
+          --exclude /CLAUDE.md \
+          --exclude /.claude/ \
           ./ "${{ inputs.env_install }}@${{ inputs.env_ssh_host }}:/sites/${{ inputs.env_install }}/"


### PR DESCRIPTION
## Summary
- Adds `--exclude /CLAUDE.md` and `--exclude /.claude/` to the root rsync in `wpengine-deploy-root.yml`, alongside the other dev-only excludes already there (`.editorconfig`, `.nvmrc`, `package.json`, etc.)

## Why
CLAUDE.md and .claude/ are Claude Code's local config/instructions for a client repo (project context, auto-mode settings) — not something that should be rsynced to a WP Engine install. Found this because pathwaysdental.ca's `CLAUDE.md`/`.claude/settings.json` got deployed to its staging site, since these excludes predate those files existing.

## Test plan
- [ ] Confirm a root deploy no longer copies `CLAUDE.md`/`.claude/` for a repo that has them
- [ ] Confirm existing excluded paths are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)